### PR TITLE
Ignore example in doc test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! or `into` calls from the [From]/[Into] trait. [`ColorInterop`] solves this by providing a strongly
 //! typed "reference" conversion to/from `cint` types. This way, you can do things like:
 //!
-//! ```rust
+//! ```rust,ignore
 //! let color_crate1 = color_crate2.into_cint().into();
 //! // or
 //! let color_crate2 = ColorCrate2::from_cint(color_crate1.into());


### PR DESCRIPTION
`cargo test` fails with:

```
   Doc-tests cint

running 1 test
test src/lib.rs - (line 40) ... FAILED

failures:

---- src/lib.rs - (line 40) stdout ----
error[E0433]: failed to resolve: use of undeclared type `ColorCrate2`
 --> src/lib.rs:43:20
  |
6 | let color_crate2 = ColorCrate2::from_cint(color_crate1.into());
  |                    ^^^^^^^^^^^ use of undeclared type `ColorCrate2`

error[E0425]: cannot find value `color_crate2` in this scope
 --> src/lib.rs:41:20
  |
4 | let color_crate1 = color_crate2.into_cint().into();
  |                    ^^^^^^^^^^^^ not found in this scope

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0425, E0433.
For more information about an error, try `rustc --explain E0425`.
```

Given that it looks like this is just an example, tag it as ignore so it doesn't result in a test failure.